### PR TITLE
 #169711417  view-all-redFlag-records

### DIFF
--- a/Server/controller/redFlagController.js
+++ b/Server/controller/redFlagController.js
@@ -30,7 +30,19 @@ class RedFlag {
     });
 
   }
-
+  // view All RedFlag Created
+  static viewRedFlag(req, res) {
+    const records = [];
+    redFlag.forEach((record) => {
+      records.push(record);
+    });
+    return res.status(200).json(
+      {
+        status: 200,
+        data: records,
+      },
+    );
+  }
 
 }
 

--- a/Server/router/redFlagRouter.js
+++ b/Server/router/redFlagRouter.js
@@ -5,5 +5,6 @@ import redFlagController from '../controller/redFlagController';
 const redFlagRoute = express.Router();
 
 redFlagRoute.post('/api/v1/redFlags', [auth], redFlagController.createRedFlag);
+redFlagRoute.get('/api/v1/red-flags', [auth], redFlagController.viewRedFlag);
 
 export default redFlagRoute;

--- a/Server/test/test.js
+++ b/Server/test/test.js
@@ -166,4 +166,25 @@ describe('BroadCaster Api', () => {
       });
     done();
   });
+  // view all redFlags created
+  it('should be able to view all redFlags created', (done) => {
+    chai.request(server)
+      .get('/api/v1/red-flags')
+      .set('token', userToken)
+      .end((error, res) => {
+        res.status.should.be.equal(200);
+      });
+    done();
+  });
+  // user should not be able to view all redFlags created without aunthenticate
+  it('should not able to view all redFlags created if you are not aunthenticate', (done) => {
+    chai.request(server)
+      .get('/api/v1/red-flags')
+      .set('token', wrongToken)
+      .end((error, res) => {
+        res.status.should.be.equal(403);
+        res.body.error.should.be.equal('Authentication failed');
+      });
+    done();
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
It allows a user to view all red-flag records created
#### Description of Task to be completed?
Has the following endpoint:
GET  /api/v1/redFlags
#### How should this be manually tested?
 Using the Postman test above endpoint with this header:
key: content-type  value: application/json
 To test authentication, add this to the header: Get TOKEN from login endpoint
key: token  value: JWT TOKEN
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A