### PR TITLE
 #169712020  view a specific redFlag record

### DIFF
--- a/Server/controller/redFlagController.js
+++ b/Server/controller/redFlagController.js
@@ -30,6 +30,7 @@ class RedFlag {
     });
 
   }
+
   // view All RedFlag Created
   static viewRedFlag(req, res) {
     const records = [];
@@ -44,6 +45,25 @@ class RedFlag {
     );
   }
 
+  // View Specific redFlag
+  static viewSpecificRedFlag(req, res) {
+    const { id } = req.params;
+    const findRedFlag = redFlag.find((redFlag) => redFlag.id === parseInt(id));
+    if (findRedFlag) {
+      return res.status(200).json(
+        {
+          status: 200,
+          data: findRedFlag,
+        },
+      );
+    }
+    res.status(404).json(
+      {
+        status: 404,
+        error: 'The RedFlag you are looking for is not available',
+      },
+    );
+  }
 }
 
 export default RedFlag;

--- a/Server/router/redFlagRouter.js
+++ b/Server/router/redFlagRouter.js
@@ -6,5 +6,6 @@ const redFlagRoute = express.Router();
 
 redFlagRoute.post('/api/v1/redFlags', [auth], redFlagController.createRedFlag);
 redFlagRoute.get('/api/v1/red-flags', [auth], redFlagController.viewRedFlag);
+redFlagRoute.get('/api/v1/red-flags/:id', [auth], redFlagController.viewSpecificRedFlag);
 
 export default redFlagRoute;

--- a/Server/test/test.js
+++ b/Server/test/test.js
@@ -187,4 +187,37 @@ describe('BroadCaster Api', () => {
       });
     done();
   });
+  // view a specific redFlag created
+  it('should be able to view a specific redFlag created', (done) => {
+    chai.request(server)
+      .get('/api/v1/red-flags/2')
+      .set('token', userToken)
+      .end((error, res) => {
+        res.status.should.be.equal(200);
+      });
+    done();
+  });
+  // User should not view a specific redFlag created without aunthenticate
+  it('should not be able to view a specific redFlag created without aunthenticate', (done) => {
+    chai.request(server)
+      .get('/api/v1/red-flags/2')
+      .set('token', wrongToken)
+      .end((error, res) => {
+        res.status.should.be.equal(403);
+        res.body.error.should.be.equal('Authentication failed');
+      });
+    done();
+  });
+  // User should not view a specific redFlag if that redFlag is not availabe.
+  it('should not be able to view a specific redFlag if that redFlag is not yet created.', (done) => {
+    chai.request(server)
+      .get('/api/v1/red-flags/50')
+      .set('token', userToken)
+      .end((error, res) => {
+        res.status.should.be.equal(404);
+        res.body.error.should.be.equal('The RedFlag you are looking for is not available');
+      });
+    done();
+  });
+
 });


### PR DESCRIPTION
#### What does this PR do?
It allows a user to view a specific red-flag record
#### Description of Task to be completed?
Has the following endpoint:
GET /api/v1/redFlags
#### How should this be manually tested?
 Using the Postman test above endpoint with this header:
key: content-type  value: application/json
 To test authentication, add this to the header: Get TOKEN from login endpoint
key: token  value: JWT TOKEN
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A