### PR TITLE
#169712846  update  comment of redFlag record

### DIFF
--- a/Server/controller/redFlagController.js
+++ b/Server/controller/redFlagController.js
@@ -64,6 +64,36 @@ class RedFlag {
       },
     );
   }
+
+  // update comment
+  static updateComment(req, res) {
+    if (req.body.comment) {
+      const { comment } = req.body;
+      const { id } = req.params;
+      const findRedFlag = redFlag.find((redFlag) => redFlag.id === parseInt(id) && redFlag.status === 'draft');
+      if (findRedFlag) {
+        const updateComment = {
+          id: findRedFlag.id,
+          title: findRedFlag.title,
+          type: findRedFlag.type,
+          comment,
+          location: findRedFlag.location,
+          status: findRedFlag.status,
+        };
+        redFlag[redFlag.indexOf(findRedFlag)] = updateComment;
+        return res.status(200).json({
+          status: 200,
+          data: {
+            id: findRedFlag.id,
+            message: 'Updated RedFlag record\s comment',
+          },
+        });
+      }
+      return res.status(404).json({ status: 404, message: 'The redFlag is not found or is already marked by authorities.' });
+    }
+    return res.status(400).json({ status: 400, message: 'comment can not be empty' });
+  }
+
 }
 
 export default RedFlag;

--- a/Server/router/redFlagRouter.js
+++ b/Server/router/redFlagRouter.js
@@ -7,5 +7,6 @@ const redFlagRoute = express.Router();
 redFlagRoute.post('/api/v1/redFlags', [auth], redFlagController.createRedFlag);
 redFlagRoute.get('/api/v1/red-flags', [auth], redFlagController.viewRedFlag);
 redFlagRoute.get('/api/v1/red-flags/:id', [auth], redFlagController.viewSpecificRedFlag);
+redFlagRoute.patch('/api/v1/red-flags/:id/comment', [auth], redFlagController.updateComment);
 
 export default redFlagRoute;

--- a/Server/test/test.js
+++ b/Server/test/test.js
@@ -219,5 +219,59 @@ describe('BroadCaster Api', () => {
       });
     done();
   });
-
+  // comment should not be possible to be updated with empty content
+  it('should not be possible to update the comment which is empty', (done) => {
+    const newRedFlag = {
+      title: 'corruption',
+      type: 'redFlag',
+      comment: '',
+      location: 'Gasabo',
+      status: 'draft',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/3/comment')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(400);
+        res.body.message.should.be.equal('comment can not be empty');
+      });
+    done();
+  });
+  // user should  be able to update comment if redFlag status is draft
+  it('should be able to update comment if redFlag status is draft', (done) => {
+    const newRedFlag = {
+      title: 'corruption',
+      type: 'redFlag',
+      comment: 'this corruption causes the poverty',
+      location: 'Gasabo',
+      status: 'draft',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/3/comment')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(200);
+      });
+    done();
+  });
+  // user should not be able to update comment if redFlag is not present or redFlag is already marked
+  it('should not be able to update comment if redFlag is not present or redFlag is already marked', (done) => {
+    const newRedFlag = {
+      title: 'corruption',
+      type: 'redFlag',
+      comment: 'This is a huge disaster',
+      location: 'Gasabo',
+      status: 'solved',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/35/comment')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(404);
+      });
+    done();
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
It allows a user to edit comment of a red-flag record created
#### Description of Task to be completed?
Has the following endpoint:
PATCH /api/v1/red-flags/:id/comment
#### How should this be manually tested?
 Using the Postman test above endpoint with this header:
key: content-type  value: application/json
 To test authentication, add this to the header: Get TOKEN from login endpoint
key: token  value: JWT TOKEN
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A