### PR TITLE
 #169712719  update location of redFlag record

### DIFF
--- a/Server/controller/redFlagController.js
+++ b/Server/controller/redFlagController.js
@@ -94,6 +94,35 @@ class RedFlag {
     return res.status(400).json({ status: 400, message: 'comment can not be empty' });
   }
 
+  // Update location
+  static updateLocation(req, res) {
+    const { id } = req.params;
+    if (req.body.location) {
+      const { location } = req.body;
+      const findRedFlag = redFlag.find((redFlag) => redFlag.id === parseInt(id));
+      if (findRedFlag && findRedFlag.status === 'draft') {
+        const updateLocation = {
+          id: findRedFlag.id,
+          title: findRedFlag.title,
+          type: findRedFlag.type,
+          comment: findRedFlag.comment,
+          location,
+          status: findRedFlag.status,
+
+        };
+        redFlag[redFlag.indexOf(findRedFlag)] = updateLocation;
+        return res.status(200).json({
+          status: 200,
+          data: [{
+            id: findRedFlag.id,
+            message: "Updated redFlag record's location",
+          }],
+        });
+      }
+      return res.status(404).json({ status: 404, message: 'The redFlag is not found or is already marked by authorities.' });
+    }
+    return res.status(400).json({ status: 400, message: 'location can not be empty' });
+  }
 }
 
 export default RedFlag;

--- a/Server/router/redFlagRouter.js
+++ b/Server/router/redFlagRouter.js
@@ -8,5 +8,6 @@ redFlagRoute.post('/api/v1/redFlags', [auth], redFlagController.createRedFlag);
 redFlagRoute.get('/api/v1/red-flags', [auth], redFlagController.viewRedFlag);
 redFlagRoute.get('/api/v1/red-flags/:id', [auth], redFlagController.viewSpecificRedFlag);
 redFlagRoute.patch('/api/v1/red-flags/:id/comment', [auth], redFlagController.updateComment);
+redFlagRoute.patch('/api/v1/red-flags/:id/location', [auth], redFlagController.updateLocation);
 
 export default redFlagRoute;

--- a/Server/test/test.js
+++ b/Server/test/test.js
@@ -274,4 +274,55 @@ describe('BroadCaster Api', () => {
       });
     done();
   });
+  // location should not be possible to be updated with empty content
+  it('should not be possible to update the location with empty content', (done) => {
+    const newRedFlag = {
+      title: 'road',
+      type: 'Intervation',
+      comment: 'This is too much',
+      location: '',
+      status: 'draft',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/3/location')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(400);
+        res.body.message.should.be.equal('location can not be empty');
+      });
+    done();
+  });
+  // user should not be able to update the location of the record which is not present && the record status which is not draft
+  it('should not be possible to update the location of record which is not present and the record status which is not draft', (done) => {
+    const newRedFlag = {
+      title: 'road',
+      type: 'Intervation',
+      comment: 'This is too much',
+      location: '-1.643883, 30.40773',
+      status: 'rejected',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/35/location')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(404);
+      });
+    done();
+  });
+  // user should be able to update the location of redFlag record
+  it('should be able to upate the location of redFlag record', (done) => {
+    const newRedFlag = {
+      location: '-1.8935, 30.27849',
+    };
+    chai.request(server)
+      .patch('/api/v1/red-flags/3/location')
+      .set('token', userToken)
+      .send(newRedFlag)
+      .end((error, res) => {
+        res.status.should.be.equal(200);
+      });
+    done();
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
It allows a user to update the location of the red-flag record
#### Description of Task to be completed?
Has the following endpoint:
PATCH /api/v1/red-flags/:id/location
#### How should this be manually tested?
 Using the Postman test above endpoint with this header:
key: content-type  value: application/json
 To test authentication, add this to the header: Get TOKEN from login endpoint
key: token  value: JWT TOKEN
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A