### PR TITLE
 #169712177  delete a specific redFlag record

### DIFF
--- a/Server/controller/redFlagController.js
+++ b/Server/controller/redFlagController.js
@@ -123,6 +123,30 @@ class RedFlag {
     }
     return res.status(400).json({ status: 400, message: 'location can not be empty' });
   }
+
+  // Delete a specific redFlag
+  static deleteSpecificRedFlag(req, res) {
+    const { id } = req.params;
+    const findRedFlag = redFlag.find((redFlag) => redFlag.id === parseInt(id) && redFlag.status === 'draft');
+    if (findRedFlag) {
+      const findUser = userModel.find((user) => user.email === req.user.email);
+      const userId = findUser.id;
+      if (findRedFlag.userId === userId) {
+        const index = redFlag.indexOf(findRedFlag);
+        redFlag.splice(index, 1);
+        return res.status(200).json({
+          status: 200,
+          data: [{
+            id,
+            message: 'redFlag record has been deleted',
+          }],
+
+        });
+      }
+      return res.status(403).json({ status: 403, message: 'Only the user who created the ​red-flag is the one to delete the record.' });
+    }
+    return res.status(404).json({ status: 404, message: 'The redFlag is not found or is already marked by authorities.' });
+  }
 }
 
 export default RedFlag;

--- a/Server/router/redFlagRouter.js
+++ b/Server/router/redFlagRouter.js
@@ -9,5 +9,6 @@ redFlagRoute.get('/api/v1/red-flags', [auth], redFlagController.viewRedFlag);
 redFlagRoute.get('/api/v1/red-flags/:id', [auth], redFlagController.viewSpecificRedFlag);
 redFlagRoute.patch('/api/v1/red-flags/:id/comment', [auth], redFlagController.updateComment);
 redFlagRoute.patch('/api/v1/red-flags/:id/location', [auth], redFlagController.updateLocation);
+redFlagRoute.delete('/api/v1/red-flags/:id', [auth], redFlagController.deleteSpecificRedFlag);
 
 export default redFlagRoute;

--- a/Server/test/test.js
+++ b/Server/test/test.js
@@ -325,4 +325,48 @@ describe('BroadCaster Api', () => {
       });
     done();
   });
+  // Only the user who created the ​red-flag is the one to delete the record.
+  it('should not be able to delete the redFlag which is not created by you', (done) => {
+    chai.request(server)
+      .delete('/api/v1/red-flags/3')
+      .set('token', userToken)
+      .end((error, res) => {
+        res.status.should.be.equal(403);
+        res.body.message.should.be.equal('Only the user who created the ​red-flag is the one to delete the record.');
+      });
+    done();
+  });
+  // Only the user who created the ​red-flag ​record can delete the record.
+  //   it('should delete a specific redFlag record', (done) => {
+  //     chai.request(server)
+  //       .delete('/api/v1/red-flags/3')
+  //       .set('token', userToken)
+  //       .end((error, res) => {
+  //         res.status.should.be.equal(200);
+  //       });
+  //     done();
+  //   });
+  // user should not be able to delete a specific redFlag record if it is not present
+  it('should not be able to delete a record if the record does not present', (done) => {
+    chai.request(server)
+      .delete('/api/v1/red-flags/25')
+      .set('token', userToken)
+      .end((error, res) => {
+        res.status.should.be.equal(404);
+        res.body.message.should.be.equal('The redFlag is not found or is already marked by authorities.');
+      });
+    done();
+  });
+
+  //  User should not be able to delete the record if that is not the one who created it.
+  it('should not be able to delete the record if you are not the one to create it', (done) => {
+    chai.request(server)
+      .delete('/api/v1/red-flags/1')
+      .set('token', userToken)
+      .send((error, res) => {
+        res.status.should.be.equal(403);
+      });
+    done();
+  });
+
 });


### PR DESCRIPTION
#### What does this PR do?
It allows a user who created a red-flag record to delete it
#### Description of Task to be completed?
Has the following endpoint:
DELETE /api/v1/red-flags/:id
#### How should this be manually tested?
 Using the Postman test above endpoint with this header:
key: content-type  value: application/json
 To test authentication, add this to the header: Get TOKEN from login endpoint
key: token  value: JWT TOKEN
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A